### PR TITLE
Fixing Sale Price Effective Date

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -457,31 +457,31 @@ class WC_Facebook_Product {
 
 		$sale_price = $this->woo_product->get_sale_price();
 		$sale_price_effective_date = '';
-
-		$sale_start =
-			( $date     = $this->woo_product->get_date_on_sale_from() )
-				? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-				: self::MIN_DATE_1 . self::MIN_TIME;
-
-		$sale_end =
-			( $date   = $this->woo_product->get_date_on_sale_to() )
-				? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-				: self::MAX_DATE . self::MAX_TIME;
+		$sale_start = '';
+		$sale_end = '';
 
 		// check if sale exist
 		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
+			$sale_start =
+				( $date     = $this->woo_product->get_date_on_sale_from() )
+					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+					: self::MIN_DATE_1 . self::MIN_TIME;
+			$sale_end =
+				( $date   = $this->woo_product->get_date_on_sale_to() )
+					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+					: self::MAX_DATE . self::MAX_TIME;
 			$sale_price_effective_date =
 				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
 				? ''
 				: $sale_start . '/' . $sale_end;
 				$sale_price =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
-		}
 
-		// Set Sale start and end as empty if set to default values
-		if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
-			$sale_start = '';
-			$sale_end   = '';
+			// Set Sale start and end as empty if set to default values
+			if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
+				$sale_start = '';
+				$sale_end   = '';
+			}
 		}
 
 		// check if sale is expired and sale time range is valid

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -470,9 +470,18 @@ class WC_Facebook_Product {
 
 		// check if sale exist
 		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
-			$sale_price_effective_date = $sale_start . '/' . $sale_end;
-			$sale_price =
+			$sale_price_effective_date =
+				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
+				? ''
+				: $sale_start . '/' . $sale_end;
+				$sale_price =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
+		}
+
+		// Set Sale start and end as empty if set to default values
+		if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
+			$sale_start = '';
+			$sale_end   = '';
 		}
 
 		// check if sale is expired and sale time range is valid

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -107,7 +107,7 @@ class fbproductTest extends WP_UnitTestCase {
 	/**
 	 * Test Data Provider for sale_price related fields
 	 */
-	public function provideSalePriceData() {
+	public function provide_sale_price_data() {
 		return [
 			[
 				11.5,
@@ -133,6 +133,16 @@ class fbproductTest extends WP_UnitTestCase {
 				null,
 				null,
 				null,
+				0,
+				'',
+				'',
+				'',
+				'',
+			],
+			[
+				null,
+				'2024-08-08',
+				'2024-08-18',
 				0,
 				'',
 				'',
@@ -175,7 +185,7 @@ class fbproductTest extends WP_UnitTestCase {
 	/**
 	 * Test that sale_price related fields are being set correctly while preparing product.
 	 *
-	 * @dataProvider provideSalePriceData
+	 * @dataProvider provide_sale_price_data
 	 * @return void
 	 */
 	public function test_sale_price_and_effective_date(

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -103,4 +103,104 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->assertEquals( $description, 'fb description' );
 
 	}
+
+	/**
+	 * Test Data Provider for sale_price related fields
+	 */
+	public function provideSalePriceData() {
+		return [
+			[
+				11.5,
+				null,
+				null,
+				1150,
+				'11.5 USD',
+				'',
+				'',
+				'',
+			],
+			[
+				0,
+				null,
+				null,
+				0,
+				'0 USD',
+				'',
+				'',
+				'',
+			],
+			[
+				null,
+				null,
+				null,
+				0,
+				'',
+				'',
+				'',
+				'',
+			],
+			[
+				11,
+				'2024-08-08',
+				null,
+				1100,
+				'11 USD',
+				'2024-08-08T00:00:00+00:00/2038-01-17T23:59+00:00',
+				'2024-08-08T00:00:00+00:00',
+				'2038-01-17T23:59+00:00',
+			],
+			[
+				11,
+				null,
+				'2024-08-08',
+				1100,
+				'11 USD',
+				'1970-01-29T00:00+00:00/2024-08-08T00:00:00+00:00',
+				'1970-01-29T00:00+00:00',
+				'2024-08-08T00:00:00+00:00',
+			],
+			[
+				11,
+				'2024-08-08',
+				'2024-08-09',
+				1100,
+				'11 USD',
+				'2024-08-08T00:00:00+00:00/2024-08-09T00:00:00+00:00',
+				'2024-08-08T00:00:00+00:00',
+				'2024-08-09T00:00:00+00:00',
+			],
+		];
+	}
+
+	/**
+	 * Test that sale_price related fields are being set correctly while preparing product.
+	 *
+	 * @dataProvider provideSalePriceData
+	 * @return void
+	 */
+	public function test_sale_price_and_effective_date(
+		$salePrice,
+		$sale_price_start_date,
+		$sale_price_end_date,
+		$expected_sale_price,
+		$expected_sale_price_for_batch,
+		$expected_sale_price_effective_date,
+		$expected_sale_price_start_date,
+		$expected_sale_price_end_date
+	) {
+		$product          = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$facebook_product->set_sale_price( $salePrice );
+		$facebook_product->set_date_on_sale_from( $sale_price_start_date );
+		$facebook_product->set_date_on_sale_to( $sale_price_end_date );
+
+		$product_data = $facebook_product->prepare_product( $facebook_product->get_id(), \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
+		$this->assertEquals( $product_data['sale_price'], $expected_sale_price_for_batch );
+		$this->assertEquals( $product_data['sale_price_effective_date'], $expected_sale_price_effective_date );
+
+		$product_data = $facebook_product->prepare_product( $facebook_product->get_id(), \WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED );
+		$this->assertEquals( $product_data['sale_price'], $expected_sale_price );
+		$this->assertEquals( $product_data['sale_price_start_date'], $expected_sale_price_start_date );
+		$this->assertEquals( $product_data['sale_price_end_date'], $expected_sale_price_end_date );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When User doesn't provide any value for sale price start/end dates then by default we set Start Date as 1970-01-29 and End Date as 2038-01-17 which is not required as it simply mocks the following Meta's internal logic:

_**A. If  sale_price_effective_date is not provided, we always consider the item as "On Sale". This means that we will always use the sale_price as the current price of the item.

B. If the sale doesn't have a start date (i.e., field sale_price_effective_date only contains end date) it will start showing the sale price immediately until the end date is reached.

C. If it doesn't have an end date (i.e., field sale_price_effective_date only contains start date) it will start showing the sale price as soon as the start date is reached and show that price indefinitely.

D. If the sale has both start and end dates (i.e., field sale_price_effective_date contains both dates) the sale_price will be used during the period of the sale.**_

Hence to avoid surfacing generic Sale Price Effective Date, we should keep it empty to keep the behaviour consistent with other partners.

### Screenshots:
Screenshots from Meta Commerce Manager

Before:
<img width="799" alt="Screenshot 2024-08-19 at 10 17 14" src="https://github.com/user-attachments/assets/ccb017b4-a322-45a8-85a2-e590f8069301">

After:
<img width="1110" alt="Screenshot 2024-08-19 at 10 17 30" src="https://github.com/user-attachments/assets/b403a8da-4070-4480-9483-1df4bb0b68fd">



### Detailed test instructions:

1. Unit test - ./vendor/bin/phpunit --filter test_sale_price_and_effective_date
2. This change only impacts sale_price_effective_date and no other product fields or user experience
3. Earlier default value for sale_price_effective_date use to be '1970-01-29T00:00+00:00/2038-01-17T23:59+00:00' when no value was set for $sale_price_start_date and $sale_price_end_date by the plugin user but now this will set as empty in that case.

### Changelog entry

> Fix - Took care of something that wasn't working.
