### PR TITLE
Fixed FB Attribute Syncing Issues

### DIFF
--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -209,13 +209,13 @@ class Advertise extends Abstract_Settings_Screen {
 			data-hide-manage-button="true"
 			data-fbe-extras="<?php echo esc_attr( $fbe_extras ); ?>"
 			data-fbe-scopes="manage_business_extension"
-			data-fbe-redirect-uri="https://mariner9.s3.amazonaws.com/"
+			data-fbe-redirect-uri="https://business.facebook.com/fbe-iframe-handler"
 			data-title="<?php esc_attr_e( 'If you are connected to Facebook but cannot display ads, please contact Facebook support.', 'facebook-for-woocommerce' ); ?>"></div>
 		<div
 			class="fb-lwi-ads-insights"
 			data-fbe-extras="<?php echo esc_attr( $fbe_extras ); ?>"
 			data-fbe-scopes="manage_business_extension"
-			data-fbe-redirect-uri="https://mariner9.s3.amazonaws.com/"></div>
+			data-fbe-redirect-uri="https://business.facebook.com/fbe-iframe-handler"></div>
 		<?php
 		$this->maybe_render_learn_more_link( __( 'Advertising', 'facebook-for-woocommerce' ) );
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -984,8 +984,8 @@ class Products {
 					$attr_name = $attribute->get_name();
 					$attr_val  = $product->get_attribute( $slug );
 				}
-
-				if ( \WC_Facebookcommerce_Utils::sanitize_variant_name( $attr_name, false ) === $key ) {
+				$sanitized_attr_name = \WC_Facebookcommerce_Utils::sanitize_attribute_name( \WC_Facebookcommerce_Utils::sanitize_variant_name( $attr_name, false ) );
+				if ( $sanitized_attr_name === $key ) {
 					$value = $attr_val;
 					break;
 				}

--- a/includes/Products/FBCategories.php
+++ b/includes/Products/FBCategories.php
@@ -64,7 +64,7 @@ class FBCategories {
 		// TODO: can perform more validations here.
 		switch ( $attribute['type'] ) {
 			case 'enum':
-				return in_array( $value, $attribute['enum_values'] );
+				return in_array( strtolower($value), $attribute['enum_values'] );
 			case 'boolean':
 				return in_array( $value, array( 'yes', 'no' ) );
 			default:

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -735,6 +735,11 @@ class WC_Facebook_Product {
 			}
 		}
 
+		// Add GTIN (Global Trade Item Number)
+		if ( $gtin = $this->woo_product->get_global_unique_id() ) {
+			$product_data['gtin'] = $gtin;
+		}
+
 		// Only use checkout URLs if they exist.
 		$checkout_url = $this->build_checkout_url( $product_url );
 		if ( $checkout_url ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -457,31 +457,31 @@ class WC_Facebook_Product {
 
 		$sale_price = $this->woo_product->get_sale_price();
 		$sale_price_effective_date = '';
-
-		$sale_start =
-			( $date     = $this->woo_product->get_date_on_sale_from() )
-				? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-				: self::MIN_DATE_1 . self::MIN_TIME;
-
-		$sale_end =
-			( $date   = $this->woo_product->get_date_on_sale_to() )
-				? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-				: self::MAX_DATE . self::MAX_TIME;
+		$sale_start = '';
+		$sale_end = '';
 
 		// check if sale exist
 		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
+			$sale_start =
+				( $date     = $this->woo_product->get_date_on_sale_from() )
+					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+					: self::MIN_DATE_1 . self::MIN_TIME;
+			$sale_end =
+				( $date   = $this->woo_product->get_date_on_sale_to() )
+					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+					: self::MAX_DATE . self::MAX_TIME;
 			$sale_price_effective_date =
 				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
 				? ''
 				: $sale_start . '/' . $sale_end;
 				$sale_price =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
-		}
 
-		// Set Sale start and end as empty if set to default values
-		if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
-			$sale_start = '';
-			$sale_end   = '';
+			// Set Sale start and end as empty if set to default values
+			if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
+				$sale_start = '';
+				$sale_end   = '';
+			}
 		}
 
 		// check if sale is expired and sale time range is valid

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -11,6 +11,7 @@
 
 require_once __DIR__ . '/fbutils.php';
 
+use WooCommerce\Facebook\Framework\Plugin\Compatibility;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Products;
 
@@ -736,7 +737,7 @@ class WC_Facebook_Product {
 		}
 
 		// Add GTIN (Global Trade Item Number)
-		if ( $gtin = $this->woo_product->get_global_unique_id() ) {
+		if ( Compatibility::is_wc_version_gte( '9.1.0' ) && $gtin = $this->woo_product->get_global_unique_id() ) {
 			$product_data['gtin'] = $gtin;
 		}
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -724,9 +724,15 @@ class WC_Facebook_Product {
 			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
 		}
 
-		// add the Commerce values (only stock quantity for the moment)
-		if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
+		// Add stock quantity if the product or variant is stock managed.
+		// In case if variant is not stock managed but parent is, fallback on parent value
+		if ( $this->woo_product->managing_stock() ) {
 			$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
+		} else if ($this->woo_product->is_type( 'variation' )) {
+			$parent_product = wc_get_product( $this->woo_product->get_parent_id());
+			if ( $parent_product && $parent_product->managing_stock()) {	
+				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
+			}
 		}
 
 		// Only use checkout URLs if they exist.

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -725,12 +725,12 @@ class WC_Facebook_Product {
 		}
 
 		// Add stock quantity if the product or variant is stock managed.
-		// In case if variant is not stock managed but parent is, fallback on parent value
+		// In case if variant is not stock managed but parent is, fallback on parent value.
 		if ( $this->woo_product->managing_stock() ) {
 			$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
-		} else if ($this->woo_product->is_type( 'variation' )) {
-			$parent_product = wc_get_product( $this->woo_product->get_parent_id());
-			if ( $parent_product && $parent_product->managing_stock()) {	
+		} else if ( $this->woo_product->is_type( 'variation' ) ) {
+			$parent_product = wc_get_product( $this->woo_product->get_parent_id() );
+			if ( $parent_product && $parent_product->managing_stock() ) {	
 				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $parent_product->get_stock_quantity() );
 			}
 		}

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -470,9 +470,18 @@ class WC_Facebook_Product {
 
 		// check if sale exist
 		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
-			$sale_price_effective_date = $sale_start . '/' . $sale_end;
-			$sale_price =
+			$sale_price_effective_date =
+				( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME )
+				? ''
+				: $sale_start . '/' . $sale_end;
+				$sale_price =
 				intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
+		}
+
+		// Set Sale start and end as empty if set to default values
+		if ( $sale_start == self::MIN_DATE_1 . self::MIN_TIME && $sale_end == self::MAX_DATE . self::MAX_TIME ) {
+			$sale_start = '';
+			$sale_end   = '';
 		}
 
 		// check if sale is expired and sale time range is valid

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -780,8 +780,7 @@ class WC_Facebook_Product {
 		}
 		$enhanced_data = array();
 
-		$category_attrs = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
-		$all_attributes = $this->get_matched_attributes_for_product( $this->woo_product, $category_attrs );
+		$all_attributes = $category_handler->get_attributes_with_fallback_to_parent_category( $google_category_id );
 
 		foreach ( $all_attributes as $attribute ) {
 			$value            = Products::get_enhanced_catalog_attribute( $attribute['key'], $this->woo_product );
@@ -802,33 +801,6 @@ class WC_Facebook_Product {
 		}
 
 		return array_merge( $product_data, $enhanced_data );
-	}
-
-
-	/**
-	 * Filters list of attributes to only those available for a given product
-	 *
-	 * @param \WC_Product $product WooCommerce Product
-	 * @param array       $all_attributes List of Enhanced Catalog attributes to match
-	 * @return array
-	 */
-	public function get_matched_attributes_for_product( $product, $all_attributes ) {
-		$matched_attributes = array();
-		$sanitized_keys     = array_map(
-			function( $key ) {
-					return \WC_Facebookcommerce_Utils::sanitize_variant_name( $key, false );
-			},
-			array_keys( $product->get_attributes() )
-		);
-
-		$matched_attributes = array_filter(
-			$all_attributes,
-			function( $attribute ) use ( $sanitized_keys ) {
-				return in_array( $attribute['key'], $sanitized_keys );
-			}
-		);
-
-		return $matched_attributes;
 	}
 
 

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -635,6 +635,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			return $name;
 		}
 
+		/*
+		* Sanitize attribute names inline with FB name
+		*/
+		public static function sanitize_attribute_name( $name ) {
+			return str_replace(array('-', ' '), '_', $name);
+		}
+
 		public static function validateGender( $gender ) {
 			if ( $gender && ! isset( self::$validGenderArray[ $gender ] ) ) {
 				$first_char = strtolower( substr( $gender, 0, 1 ) );

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -156,18 +156,18 @@ class fbproductTest extends WP_UnitTestCase {
                     "gender" => "female"
                 ),
             ],
-            // Woo attributes with space, '-' and different casing
+            // Woo attributes with space, '-' and different casing of enum attribute
             [
                 173,
                 array(
-                    "age group" => "teen",
+                    "age group" => "Teen",
                     "is-costume" => "yes",
                     "Sunglasses Width" => "narrow"
                 ),
                 array(
                 ),
                 array(
-                    "age_group" => "teen",
+                    "age_group" => "Teen",
                     "is_costume" => "yes",
                     "sunglasses_width" => "narrow"
                 ),

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -107,7 +107,7 @@ class fbproductTest extends WP_UnitTestCase {
 	/**
 	 * Test Data Provider for sale_price related fields
 	 */
-	public function provideSalePriceData() {
+	public function provide_sale_price_data() {
 		return [
 			[
 				11.5,
@@ -133,6 +133,16 @@ class fbproductTest extends WP_UnitTestCase {
 				null,
 				null,
 				null,
+				0,
+				'',
+				'',
+				'',
+				'',
+			],
+			[
+				null,
+				'2024-08-08',
+				'2024-08-18',
 				0,
 				'',
 				'',
@@ -175,7 +185,7 @@ class fbproductTest extends WP_UnitTestCase {
 	/**
 	 * Test that sale_price related fields are being set correctly while preparing product.
 	 *
-	 * @dataProvider provideSalePriceData
+	 * @dataProvider provide_sale_price_data
 	 * @return void
 	 */
 	public function test_sale_price_and_effective_date(

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -104,149 +104,149 @@ class fbproductTest extends WP_UnitTestCase {
 
 	}
 
-  /**
-   * Test Data Provider for product category attributes
-   */
-  public function provide_category_data()
-  {
-      return [
-          // Only FB attributes
-          [
-              173,
-              array(
-              ),
-              array(
-                  "size" => "medium",
-                  "gender" => "female"
-              ),
-              array(
-                  "size" => "medium",
-                  "gender" => "female"
-              ),
-          ],
-          // Only Woo attributes
-          [
-              173,
-              array(
-                  "size" => "medium",
-                  "gender" => "female"
-              ),
-              array(
-              ),
-              array(
-                  "size" => "medium",
-                  "gender" => "female"
-              ),
-          ],
-          // Both Woo and FB attributes
-          [
-              173,
-              array(
-                  "color" => "black",
-                  "material" => "cotton"
-              ),
-              array(
-                  "size" => "medium",
-                  "gender" => "female"
-              ),
-              array(
-                  "color" => "black",
-                  "material" => "cotton",
-                  "size" => "medium",
-                  "gender" => "female"
-              ),
-          ],
-          // Woo attributes with space, '-' and different casing of enum attribute
-          [
-              173,
-              array(
-                  "age group" => "Teen",
-                  "is-costume" => "yes",
-                  "Sunglasses Width" => "narrow"
-              ),
-              array(
-              ),
-              array(
-                  "age_group" => "Teen",
-                  "is_costume" => "yes",
-                  "sunglasses_width" => "narrow"
-              ),
-          ],
-          // FB attributes overriding Woo attributes
-          [
-              173,
-              array(
-                  "age_group" => "teen",
-                  "size" => "medium",
-              ),
-              array(
-                  "age_group" => "toddler",
-                  "size" => "large",
-              ),
-              array(
-                  "age_group" => "toddler",
-                  "size" => "large",
-              ),
-          ],
-      ];
-  }
+    /**
+     * Test Data Provider for product category attributes
+     */
+    public function provide_category_data()
+    {
+        return [
+            // Only FB attributes
+            [
+                173,
+                array(
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+            ],
+            // Only Woo attributes
+            [
+                173,
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+                array(
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+            ],
+            // Both Woo and FB attributes
+            [
+                173,
+                array(
+                    "color" => "black",
+                    "material" => "cotton"
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+                array(
+                    "color" => "black",
+                    "material" => "cotton",
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+            ],
+            // Woo attributes with space, '-' and different casing of enum attribute
+            [
+                173,
+                array(
+                    "age group" => "Teen",
+                    "is-costume" => "yes",
+                    "Sunglasses Width" => "narrow"
+                ),
+                array(
+                ),
+                array(
+                    "age_group" => "Teen",
+                    "is_costume" => "yes",
+                    "sunglasses_width" => "narrow"
+                ),
+            ],
+            // FB attributes overriding Woo attributes
+            [
+                173,
+                array(
+                    "age_group" => "teen",
+                    "size" => "medium",
+                ),
+                array(
+                    "age_group" => "toddler",
+                    "size" => "large",
+                ),
+                array(
+                    "age_group" => "toddler",
+                    "size" => "large",
+                ),
+            ],
+        ];
+    }
 
-  /**
-   * Test that attribute related fields are being set correctly while preparing product.
-   *
-   * @dataProvider provide_category_data
-   * @return void
-   */
-  public function test_enhanced_catalog_fields_from_attributes(
-      $category_id,
-      $woo_attributes,
-      $fb_attributes,
-      $expected_attributes
-  ) {
-      $product          = WC_Helper_Product::create_simple_product();
-      $product->update_meta_data('_wc_facebook_google_product_category', $category_id);
+    /**
+     * Test that attribute related fields are being set correctly while preparing product.
+     *
+     * @dataProvider provide_category_data
+     * @return void
+     */
+    public function test_enhanced_catalog_fields_from_attributes(
+        $category_id,
+        $woo_attributes,
+        $fb_attributes,
+        $expected_attributes
+    ) {
+        $product          = WC_Helper_Product::create_simple_product();
+        $product->update_meta_data('_wc_facebook_google_product_category', $category_id);
 
-      // Set Woo attributes
-      $attributes = array();
-      $position = 0;
-      foreach ($woo_attributes as $key => $value) {
-          $attribute = new WC_Product_Attribute();
-          $attribute->set_id(0);
-          $attribute->set_name($key);
-          $attribute->set_options(array($value));
-          $attribute->set_position($position++);
-          $attribute->set_visible(1);
-          $attribute->set_variation(0);
-          $attributes[] = $attribute;
-      }
-      $product->set_attributes($attributes);
+        // Set Woo attributes
+        $attributes = array();
+        $position = 0;
+        foreach ($woo_attributes as $key => $value) {
+            $attribute = new WC_Product_Attribute();
+            $attribute->set_id(0);
+            $attribute->set_name($key);
+            $attribute->set_options(array($value));
+            $attribute->set_position($position++);
+            $attribute->set_visible(1);
+            $attribute->set_variation(0);
+            $attributes[] = $attribute;
+        }
+        $product->set_attributes($attributes);
 
-      // Set FB sttributes
-      foreach ($fb_attributes as $key => $value) {
-          $product->update_meta_data('_wc_facebook_enhanced_catalog_attributes_'.$key, $value);
-      }
-      $product->save_meta_data();
+        // Set FB sttributes
+        foreach ($fb_attributes as $key => $value) {
+            $product->update_meta_data('_wc_facebook_enhanced_catalog_attributes_'.$key, $value);
+        }
+        $product->save_meta_data();
 
-      // Prepare Product and validate assertions
-      $facebook_product = new \WC_Facebook_Product($product);
-      $product_data = $facebook_product->prepare_product(
-          $facebook_product->get_id(),
-          \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH
-      );
-      $this->assertEquals($product_data['google_product_category'], $category_id);
-      foreach ($expected_attributes as $key => $value) {
-          $this->assertEquals($product_data[$key], $value);
-      }
+        // Prepare Product and validate assertions
+        $facebook_product = new \WC_Facebook_Product($product);
+        $product_data = $facebook_product->prepare_product(
+            $facebook_product->get_id(),
+            \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH
+        );
+        $this->assertEquals($product_data['google_product_category'], $category_id);
+        foreach ($expected_attributes as $key => $value) {
+            $this->assertEquals($product_data[$key], $value);
+        }
 
-      $product_data = $facebook_product->prepare_product(
-          $facebook_product->get_id(),
-          \WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED
-      );
-      $this->assertEquals($product_data['category'], 173);
-      foreach ($expected_attributes as $key => $value) {
-          $this->assertEquals($product_data[$key], $value);
-      }
-  }
+        $product_data = $facebook_product->prepare_product(
+            $facebook_product->get_id(),
+            \WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED
+        );
+        $this->assertEquals($product_data['category'], 173);
+        foreach ($expected_attributes as $key => $value) {
+            $this->assertEquals($product_data[$key], $value);
+        }
+    }
   
 	/**
 	 * Test Data Provider for sale_price related fields

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -304,4 +304,60 @@ class fbproductTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $data['quantity_to_sell_on_facebook'], 128 );
 	}
+
+	/**
+	 * Test GTIN is added for simple product 
+	 * @return void
+	 */
+	public function test_gtin_for_simple_product_set() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$woo_product->set_global_unique_id(9504000059446);
+		
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['gtin'], 9504000059446 );
+	}
+
+	/**
+	 * Test GTIN is not added for simple product
+	 * @return void
+	 */
+	public function test_gtin_for_simple_product_unset() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+		$this->assertEquals(isset($data['gtin']), false);
+	}
+
+	/**
+	 * Test GTIN is added for variable product
+	 * @return void
+	 */
+	public function test_gtin_for_variable_product_set() {
+		$woo_product = WC_Helper_Product::create_variation_product();
+		$woo_variation = wc_get_product($woo_product->get_children()[0]);
+		$woo_variation->set_global_unique_id(9504000059446);
+
+		$fb_parent_product = new \WC_Facebook_Product($woo_product);
+		$fb_product = new \WC_Facebook_Product( $woo_variation, $fb_parent_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['gtin'], 9504000059446 );
+	}
+
+	/**
+	 * Test GTIN is not added for variable product
+	 * @return void
+	 */
+	public function test_gtin_for_variable_product_unset() {
+		$woo_product = WC_Helper_Product::create_variation_product();
+		$woo_variation = wc_get_product($woo_product->get_children()[0]);
+
+		$fb_parent_product = new \WC_Facebook_Product($woo_product);
+		$fb_product = new \WC_Facebook_Product( $woo_variation, $fb_parent_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals(isset($data['gtin']), false);
+	}
 }

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -103,4 +103,148 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->assertEquals( $description, 'fb description' );
 
 	}
+
+    /**
+     * Test Data Provider for product category attributes
+     */
+    public function provide_category_data()
+    {
+        return [
+            // Only FB attributes
+            [
+                173,
+                array(
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+            ],
+            // Only Woo attributes
+            [
+                173,
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+                array(
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+            ],
+            // Both Woo and FB attributes
+            [
+                173,
+                array(
+                    "color" => "black",
+                    "material" => "cotton"
+                ),
+                array(
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+                array(
+                    "color" => "black",
+                    "material" => "cotton",
+                    "size" => "medium",
+                    "gender" => "female"
+                ),
+            ],
+            // Woo attributes with space, '-' and different casing
+            [
+                173,
+                array(
+                    "age group" => "teen",
+                    "is-costume" => "yes",
+                    "Sunglasses Width" => "narrow"
+                ),
+                array(
+                ),
+                array(
+                    "age_group" => "teen",
+                    "is_costume" => "yes",
+                    "sunglasses_width" => "narrow"
+                ),
+            ],
+            // FB attributes overriding Woo attributes
+            [
+                173,
+                array(
+                    "age_group" => "teen",
+                    "size" => "medium",
+                ),
+                array(
+                    "age_group" => "toddler",
+                    "size" => "large",
+                ),
+                array(
+                    "age_group" => "toddler",
+                    "size" => "large",
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * Test that attribute related fields are being set correctly while preparing product.
+     *
+     * @dataProvider provide_category_data
+     * @return void
+     */
+    public function test_enhanced_catalog_fields_from_attributes(
+        $category_id,
+        $woo_attributes,
+        $fb_attributes,
+        $expected_attributes
+    ) {
+        $product          = WC_Helper_Product::create_simple_product();
+        $product->update_meta_data('_wc_facebook_google_product_category', $category_id);
+
+        // Set Woo attributes
+        $attributes = array();
+        $position = 0;
+        foreach ($woo_attributes as $key => $value) {
+            $attribute = new WC_Product_Attribute();
+            $attribute->set_id(0);
+            $attribute->set_name($key);
+            $attribute->set_options(array($value));
+            $attribute->set_position($position++);
+            $attribute->set_visible(1);
+            $attribute->set_variation(0);
+            $attributes[] = $attribute;
+        }
+        $product->set_attributes($attributes);
+
+        // Set FB sttributes
+        foreach ($fb_attributes as $key => $value) {
+            $product->update_meta_data('_wc_facebook_enhanced_catalog_attributes_'.$key, $value);
+        }
+        $product->save_meta_data();
+
+        // Prepare Product and validate assertions
+        $facebook_product = new \WC_Facebook_Product($product);
+        $product_data = $facebook_product->prepare_product(
+            $facebook_product->get_id(),
+            \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH
+        );
+        $this->assertEquals($product_data['google_product_category'], $category_id);
+        foreach ($expected_attributes as $key => $value) {
+            $this->assertEquals($product_data[$key], $value);
+        }
+
+        $product_data = $facebook_product->prepare_product(
+            $facebook_product->get_id(),
+            \WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED
+        );
+        $this->assertEquals($product_data['category'], 173);
+        foreach ($expected_attributes as $key => $value) {
+            $this->assertEquals($product_data[$key], $value);
+        }
+    }
 }

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -103,4 +103,104 @@ class fbproductTest extends WP_UnitTestCase {
 		$this->assertEquals( $description, 'fb description' );
 
 	}
+
+	/**
+	 * Test Data Provider for sale_price related fields
+	 */
+	public function provideSalePriceData() {
+		return [
+			[
+				11.5,
+				null,
+				null,
+				1150,
+				'11.5 USD',
+				'',
+				'',
+				'',
+			],
+			[
+				0,
+				null,
+				null,
+				0,
+				'0 USD',
+				'',
+				'',
+				'',
+			],
+			[
+				null,
+				null,
+				null,
+				0,
+				'',
+				'',
+				'',
+				'',
+			],
+			[
+				11,
+				'2024-08-08',
+				null,
+				1100,
+				'11 USD',
+				'2024-08-08T00:00:00+00:00/2038-01-17T23:59+00:00',
+				'2024-08-08T00:00:00+00:00',
+				'2038-01-17T23:59+00:00',
+			],
+			[
+				11,
+				null,
+				'2024-08-08',
+				1100,
+				'11 USD',
+				'1970-01-29T00:00+00:00/2024-08-08T00:00:00+00:00',
+				'1970-01-29T00:00+00:00',
+				'2024-08-08T00:00:00+00:00',
+			],
+			[
+				11,
+				'2024-08-08',
+				'2024-08-09',
+				1100,
+				'11 USD',
+				'2024-08-08T00:00:00+00:00/2024-08-09T00:00:00+00:00',
+				'2024-08-08T00:00:00+00:00',
+				'2024-08-09T00:00:00+00:00',
+			],
+		];
+	}
+
+	/**
+	 * Test that sale_price related fields are being set correctly while preparing product.
+	 *
+	 * @dataProvider provideSalePriceData
+	 * @return void
+	 */
+	public function test_sale_price_and_effective_date(
+		$salePrice,
+		$sale_price_start_date,
+		$sale_price_end_date,
+		$expected_sale_price,
+		$expected_sale_price_for_batch,
+		$expected_sale_price_effective_date,
+		$expected_sale_price_start_date,
+		$expected_sale_price_end_date
+	) {
+		$product          = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$facebook_product->set_sale_price( $salePrice );
+		$facebook_product->set_date_on_sale_from( $sale_price_start_date );
+		$facebook_product->set_date_on_sale_to( $sale_price_end_date );
+
+		$product_data = $facebook_product->prepare_product( $facebook_product->get_id(), \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
+		$this->assertEquals( $product_data['sale_price'], $expected_sale_price_for_batch );
+		$this->assertEquals( $product_data['sale_price_effective_date'], $expected_sale_price_effective_date );
+
+		$product_data = $facebook_product->prepare_product( $facebook_product->get_id(), \WC_Facebook_Product::PRODUCT_PREP_TYPE_FEED );
+		$this->assertEquals( $product_data['sale_price'], $expected_sale_price );
+		$this->assertEquals( $product_data['sale_price_start_date'], $expected_sale_price_start_date );
+		$this->assertEquals( $product_data['sale_price_end_date'], $expected_sale_price_end_date );
+	}
 }


### PR DESCRIPTION
# Changes proposed in this Pull Request:

## Fixed FB Attribute Syncing Issues with Simple Products:
### Issue 1 - FB Attributes are not always synced
Existing Behaviour:
- FB attributes will be synced **only** when corresponding Woo product attribute has been added in 'Attributes' tab.
- Priority is given to FB attribute value over Woo product attribute value.
- If no FB attribute value provided then fallback to Woo attribute value provided in 'Attributes' tab.

Modified Behaviour:
- For Simple Products, FB attributes will be always be synced and will be given precedence over Woo attribute value provided in 'Attributes' tab.
- For Variable Products, FB attributes will be always be synced, however precedence will be given to Variation attribute values provided in Variation tab. 


### Issue 2 - Attribute value syncing broken for attributes with multiple words
Existing Behaviour:
- If Woo product attribute name doesn't contain '_' then corresponding FB attribute value will never be synced.
- Attribute names like 'Age Group' or 'age-group' never gets synced

Modified Behaviour:
- Extra characters like '-' and ' ' will be replaced by '_' for successful attribute name match, thus syncing such attributes.  

### Issue 3 - Attribute value syncing broken for enum attributes with non-lowercase values
Existing Behaviour:
- If Woo product attribute name contain camel casing for an enum FB attribute then it will never be synced.
- If enum attribute like 'Age Group' have value as 'Newborn' then it will never be synced unless its changed to 'newborn'

Modified Behaviour:
- Enum attribute values converted to lowercase while matching with allowed enum values. 

### Screenshots:

#### **Before**
Attributes Tab:
<img width="323" alt="Screenshot 2024-09-01 at 22 51 15" src="https://github.com/user-attachments/assets/3241ebed-4b1e-4296-b60e-ef8bfaa62e95">
FB Tab:
<img width="302" alt="Screenshot 2024-09-01 at 22 51 36" src="https://github.com/user-attachments/assets/d4b3390a-d70e-429e-ace3-e21694c32630">
Commerce Manager:
<img width="739" alt="Screenshot 2024-09-01 at 22 53 28" src="https://github.com/user-attachments/assets/e863e60a-e72a-445f-bde5-9ae52a5a1153">
<img width="740" alt="Screenshot 2024-09-01 at 22 53 42" src="https://github.com/user-attachments/assets/6dabe26f-9e3b-4421-b061-3bbf2b4a0b6d">
<img width="746" alt="Screenshot 2024-09-01 at 22 53 50" src="https://github.com/user-attachments/assets/9a76f956-3d0c-4745-b82e-36cd26da9447">


In the snapshots you can see that: 
- Age Group didn't get synced due to space in their name
- Gender didn't get synced due to came casing 'Male' in its value.
- Sunglass-Width didn't get synced as it has '-' in its name
- Sports Team didn't get synced as its not added in Attributes Tab
- Theme got correctly overwritten


#### **After**
Attributes Tab:
<img width="344" alt="Screenshot 2024-09-01 at 22 31 21" src="https://github.com/user-attachments/assets/3a5b2b90-5650-4efb-a9d8-0c5c933fce17">
FB Tab:
<img width="281" alt="Screenshot 2024-09-01 at 22 31 58" src="https://github.com/user-attachments/assets/7e66bac0-2cb5-4bab-8a99-2d1ffb7e3ee1">
Commerce Manager:
<img width="997" alt="Screenshot 2024-09-01 at 22 32 58" src="https://github.com/user-attachments/assets/b1fe2ab7-d8f4-4b41-b356-0e1cafd1785e">
<img width="993" alt="Screenshot 2024-09-01 at 22 33 58" src="https://github.com/user-attachments/assets/c3e2a0c4-4b7e-488e-a177-18c3d2c729b6">


In the snapshots you can see that: 
- FB attribute value for Theme overridden the Woo attribute value 
- Age Group is not provided in FB attribute so its fallback to Woo attribute value
- Age Group has 'Newborn' as attribute value still got synced.
- Age Group has space in their name and sunglasses-width has '-' in their attribute name still got synced

### Detailed test instructions:

Unit test - ./vendor/bin/phpunit --filter test_enhanced_catalog_fields_from_attributes

### Changelog entry

> Fixed FB category specific attributes syncing
