### PR TITLE
Fixed product url at top of Edit Product page

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1630,8 +1630,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		if ( $fb_product_item_id ) {
 			$this->display_success_message(
-				'Created product  <a href="https://facebook.com/' . $fb_product_item_id .
-				'" target="_blank">' . $fb_product_item_id . '</a> on Facebook.'
+				'<a href="https://business.facebook.com/commerce/catalogs/'.
+				$this->get_product_catalog_id().
+				'/products/'. '" target="_blank">' .
+				'View product on Meta catalog</a>'
 			);
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolved issue with Product URL on Edit Product page. Previously, clicking the URL would lead to a broken page. Now, it correctly redirects to the Items tab in Commerce Manager.

### Screenshots:
<img width="418" alt="Screenshot 2024-11-25 at 19 13 41" src="https://github.com/user-attachments/assets/8323600c-a58e-4ac5-aedf-e30e65211f52">

<img width="373" alt="Screenshot 2024-11-25 at 19 15 49" src="https://github.com/user-attachments/assets/a4dfae8c-7520-464f-8b21-28c0789a0de6">


### Detailed test instructions:

1. Create a new product
2. Click on the link 'View product on Meta catalog'
3. This should navigate to the Commerce Manager of connected catalog

### Changelog entry

> Fixed product url at top of Edit Product page