### PR TITLE
Fix Facebook Product Sync Box

### DIFF
--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -80,8 +80,7 @@ class Product_Sync_Meta_Box {
 
 			?>
 
-			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?>
-			<a href="https://facebook.com/<?php echo esc_attr( $fb_product_id ); ?>" target="_blank"><?php echo esc_html( $fb_product_id ); ?></a>
+			<a href="https://business.facebook.com/commerce/catalogs/<?php echo esc_attr( $fb_integration->get_product_catalog_id() ); ?>/products/" target="_blank"><?php echo esc_html( 'View product on Meta catalog' ); ?></a>
 
 			<?php if ( \WC_Facebookcommerce_Utils::is_variable_type( $fb_product->get_type() ) ) : ?>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "facebook-for-woocommerce",
-      "version": "3.2.10",
+      "version": "3.3.0",
       "license": "GPL-2.0",
       "devDependencies": {
         "@wordpress/env": "^9.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "facebook-for-woocommerce",
-      "version": "3.3.0",
+      "version": "3.2.10",
       "license": "GPL-2.0",
       "devDependencies": {
         "@wordpress/env": "^9.10.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolved issue with Product URL in Facebook Product Sync Box. Previously, clicking the URL would lead to a broken page. Now, it correctly redirects to the Items tab in Commerce Manager.

### Screenshots:
Before
<img width="295" alt="Screenshot 2024-11-25 at 19 29 28" src="https://github.com/user-attachments/assets/71eab2ec-c031-407e-87f7-d9b5841fcb0a">


After
<img width="294" alt="Screenshot 2024-11-25 at 19 29 40" src="https://github.com/user-attachments/assets/02abab87-1cf6-4f94-b882-9dc24364fbf3">


### Detailed test instructions:

1. Create a new product
2. Click on the link 'View product on Meta catalog'
3. This should navigate to the Commerce Manager of connected catalog


### Changelog entry

> Fixed product url in Facebook Product Sync Box
